### PR TITLE
ci(docker): 更新目录权限设置

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -7,6 +7,8 @@ TZ=${TZ:-Asia/Shanghai}
 
 mkdir -p /log
 
+chown ${USER_UID}:${USER_GID} /jmalcloud
+
 chown -R ${USER_UID}:${USER_GID} /jmalcloud/models
 chown -R ${USER_UID}:${USER_GID} /jmalcloud/tess4j
 chown ${USER_UID}:${USER_GID} /jmalcloud/ip2region.xdb


### PR DESCRIPTION
- 在 jmalcloud 目录下新增 chown 命令，确保正确设置目录所有者
- 优化权限设置顺序，先设置父目录再设置子目录