### PR TITLE
refactor(file): 优化文件下载和预览功能

### DIFF
--- a/src/main/java/com/jmal/clouddisk/controller/rest/ShareController.java
+++ b/src/main/java/com/jmal/clouddisk/controller/rest/ShareController.java
@@ -20,15 +20,12 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ContentDisposition;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody;
-import org.springframework.web.util.UriUtils;
 
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.*;
@@ -241,8 +238,6 @@ public class ShareController {
         }
         return file.<ResponseEntity<Object>>map(fileDocument ->
                 ResponseEntity.ok()
-                        .header(HttpHeaders.CONTENT_DISPOSITION, "fileName=" + ContentDisposition.builder("attachment")
-                                .filename(UriUtils.encode(fileDocument.getName(), StandardCharsets.UTF_8)))
                         .header(HttpHeaders.CONTENT_TYPE, fileDocument.getContentType())
                         .header(HttpHeaders.CONNECTION, "close")
                         .header(HttpHeaders.CONTENT_LENGTH, String.valueOf(fileDocument.getContent().length))

--- a/src/main/java/com/jmal/clouddisk/interceptor/FileInterceptor.java
+++ b/src/main/java/com/jmal/clouddisk/interceptor/FileInterceptor.java
@@ -108,7 +108,7 @@ public class FileInterceptor implements HandlerInterceptor {
         if (!CharSequenceUtil.isBlank(operation)) {
             switch (operation) {
                 case DOWNLOAD -> {
-                    response.setHeader(HttpHeaders.CONTENT_DISPOSITION, "attachment;filename=" + filename);
+                    response.setHeader(HttpHeaders.CONTENT_DISPOSITION, "attachment;filename=\"" + filename + "\"");
                     if (downloadOssFile(request, response, filename, path)) return false;
                 }
                 case PREVIEW -> {

--- a/src/main/java/com/jmal/clouddisk/oss/web/WebOssService.java
+++ b/src/main/java/com/jmal/clouddisk/oss/web/WebOssService.java
@@ -634,7 +634,7 @@ public class WebOssService extends WebOssCommonService {
         BucketInfo bucketInfo = CaffeineUtil.getOssDiameterPrefixCache(ossPath);
         Path path = Paths.get(ossPath);
         try {
-            if (Boolean.TRUE.equals(isFolder)) {
+            if (BooleanUtil.isTrue(isFolder)) {
                 ossService.mkdir(objectName);
                 fileInfo = BaseOssService.newFileInfo(objectName, bucketInfo.getBucketName());
             } else {
@@ -680,7 +680,7 @@ public class WebOssService extends WebOssCommonService {
         notifyUpdateFile(ossPath, objectName, contentText.length());
     }
 
-    public void download(String ossPath, Path prePth, HttpServletRequest request, HttpServletResponse response) {
+    public void download(String ossPath, Path prePth, HttpServletRequest request, HttpServletResponse response, String downloadFilename) {
         IOssService ossService = OssConfigService.getOssStorageService(ossPath);
         String objectName = getObjectName(prePth, ossPath, false);
         try (AbstractOssObject abstractOssObject = ossService.getAbstractOssObject(objectName);
@@ -689,6 +689,9 @@ public class WebOssService extends WebOssCommonService {
              OutputStream outputStream = response.getOutputStream()) {
             FileInfo fileInfo = ossService.getFileInfo(objectName);
             String encodedFilename = URLEncoder.encode(fileInfo.getName(), StandardCharsets.UTF_8);
+            if (CharSequenceUtil.isNotBlank(downloadFilename)) {
+                response.setHeader(HttpHeaders.CONTENT_DISPOSITION, "attachment;filename=" + downloadFilename);
+            }
             String suffix = FileUtil.getSuffix(encodedFilename);
             // 设置响应头
             response.setContentType(FileContentTypeUtils.getContentType(suffix));

--- a/src/main/java/com/jmal/clouddisk/oss/web/WebOssService.java
+++ b/src/main/java/com/jmal/clouddisk/oss/web/WebOssService.java
@@ -690,7 +690,7 @@ public class WebOssService extends WebOssCommonService {
             FileInfo fileInfo = ossService.getFileInfo(objectName);
             String encodedFilename = URLEncoder.encode(fileInfo.getName(), StandardCharsets.UTF_8);
             if (CharSequenceUtil.isNotBlank(downloadFilename)) {
-                response.setHeader(HttpHeaders.CONTENT_DISPOSITION, "attachment;filename=" + downloadFilename);
+                response.setHeader(HttpHeaders.CONTENT_DISPOSITION, "attachment;filename=\"" + downloadFilename + "\"");
             }
             String suffix = FileUtil.getSuffix(encodedFilename);
             // 设置响应头
@@ -729,7 +729,6 @@ public class WebOssService extends WebOssCommonService {
         long end = ranges[1] == -1 ? fileSize - 1 : ranges[1];
         try (AbstractOssObject rangeObject = ossService.getAbstractOssObject(objectName, start, end);
              InputStream rangeIn = rangeObject.getInputStream()) {
-            response.setHeader(HttpHeaders.CONTENT_DISPOSITION, "inline;filename=" + encodedFilename);
             response.setStatus(HttpServletResponse.SC_PARTIAL_CONTENT);
             String contentRange = "bytes " + start + "-" + end + "/" + fileSize;
             response.setHeader(HttpHeaders.CONTENT_RANGE, contentRange);

--- a/src/main/java/com/jmal/clouddisk/service/impl/CommonFileService.java
+++ b/src/main/java/com/jmal/clouddisk/service/impl/CommonFileService.java
@@ -58,7 +58,6 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
-import org.springframework.web.util.UriUtils;
 
 import javax.imageio.IIOImage;
 import javax.imageio.ImageIO;
@@ -145,7 +144,7 @@ public class CommonFileService {
 
     public ResponseEntity<Object> getObjectResponseEntity(FileDocument fileDocument) {
         if (fileDocument != null) {
-            return ResponseEntity.ok().header(HttpHeaders.CONTENT_DISPOSITION, "fileName=" + UriUtils.encode(fileDocument.getName(), StandardCharsets.UTF_8)).header(HttpHeaders.CONTENT_TYPE, fileDocument.getContentType()).header(HttpHeaders.CONNECTION, "close").header(HttpHeaders.CONTENT_LENGTH, String.valueOf(fileDocument.getContent() != null ? fileDocument.getContent().length : 0)).header(HttpHeaders.CONTENT_ENCODING, "utf-8").header(HttpHeaders.CACHE_CONTROL, "public, max-age=604800").body(fileDocument.getContent());
+            return ResponseEntity.ok().header(HttpHeaders.CONTENT_TYPE, fileDocument.getContentType()).header(HttpHeaders.CONNECTION, "close").header(HttpHeaders.CONTENT_LENGTH, String.valueOf(fileDocument.getContent() != null ? fileDocument.getContent().length : 0)).header(HttpHeaders.CONTENT_ENCODING, "utf-8").header(HttpHeaders.CACHE_CONTROL, "public, max-age=604800").body(fileDocument.getContent());
         } else {
             return ResponseEntity.status(HttpStatus.NOT_FOUND).body("找不到该文件");
         }

--- a/src/main/java/com/jmal/clouddisk/service/impl/FileServiceImpl.java
+++ b/src/main/java/com/jmal/clouddisk/service/impl/FileServiceImpl.java
@@ -53,6 +53,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.data.mongodb.core.query.Update;
+import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody;
@@ -807,7 +808,7 @@ public class FileServiceImpl extends CommonFileService implements IFileService {
         } else {
             downloadName = URLEncoder.encode(downloadName, StandardCharsets.UTF_8);
         }
-        response.setHeader("Content-Disposition", "attachment;fileName=\"" + downloadName + "\"");
+        response.setHeader(HttpHeaders.CONTENT_DISPOSITION, "attachment;fileName=\"" + downloadName + "\"");
     }
 
     /**

--- a/src/main/java/com/jmal/clouddisk/service/impl/FileServiceImpl.java
+++ b/src/main/java/com/jmal/clouddisk/service/impl/FileServiceImpl.java
@@ -808,7 +808,7 @@ public class FileServiceImpl extends CommonFileService implements IFileService {
         } else {
             downloadName = URLEncoder.encode(downloadName, StandardCharsets.UTF_8);
         }
-        response.setHeader(HttpHeaders.CONTENT_DISPOSITION, "attachment;fileName=\"" + downloadName + "\"");
+        response.setHeader(HttpHeaders.CONTENT_DISPOSITION, "attachment;filename=\"" + downloadName + "\"");
     }
 
     /**

--- a/src/main/java/com/jmal/clouddisk/service/impl/FileVersionServiceImpl.java
+++ b/src/main/java/com/jmal/clouddisk/service/impl/FileVersionServiceImpl.java
@@ -48,7 +48,6 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody;
-import org.springframework.web.util.UriUtils;
 
 import java.io.*;
 import java.nio.charset.Charset;
@@ -421,9 +420,7 @@ public class FileVersionServiceImpl implements IFileVersionService {
             return ResponseEntity.notFound().build();
         }
         try (InputStream inputStream = getInputStream(gridFSFile)) {
-            String filename = gridFSFile.getMetadata().getString(Constants.FILENAME);
             HttpHeaders headers = new HttpHeaders();
-            headers.add(HttpHeaders.CONTENT_DISPOSITION, "inline;filename=" + UriUtils.encode(filename, StandardCharsets.UTF_8));
             return ResponseEntity.ok()
                     .headers(headers)
                     .contentType(MediaType.parseMediaType("application/octet-stream"))

--- a/src/main/java/com/jmal/clouddisk/service/impl/FileVersionServiceImpl.java
+++ b/src/main/java/com/jmal/clouddisk/service/impl/FileVersionServiceImpl.java
@@ -423,7 +423,7 @@ public class FileVersionServiceImpl implements IFileVersionService {
         try (InputStream inputStream = getInputStream(gridFSFile)) {
             String filename = gridFSFile.getMetadata().getString(Constants.FILENAME);
             HttpHeaders headers = new HttpHeaders();
-            headers.add(HttpHeaders.CONTENT_DISPOSITION, "attachment;filename=" + UriUtils.encode(filename, StandardCharsets.UTF_8));
+            headers.add(HttpHeaders.CONTENT_DISPOSITION, "inline;filename=" + UriUtils.encode(filename, StandardCharsets.UTF_8));
             return ResponseEntity.ok()
                     .headers(headers)
                     .contentType(MediaType.parseMediaType("application/octet-stream"))


### PR DESCRIPTION
- 统一使用 HttpHeaders.CONTENT_DISPOSITION 设置响应头
- 优化文件名编码处理，防止中文文件名乱码
- 调整预览功能，不再设置 Content-Disposition 头
- 重构 FileInterceptor 中的逻辑，提高代码可读性- 更新 FileServiceImpl 和 FileVersionServiceImpl 中的文件下载实现
- 修改 WebOssService 中的 download 方法，支持自定义文件名